### PR TITLE
Make The Logic For Protected Routes

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -19,10 +19,8 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
-      ],
+      'react-hooks/exhaustive-deps': false,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     },
-  },
+  }
 )

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { NextUIProvider } from '@nextui-org/react'
 import { useNavigate, useHref, Route, Routes } from 'react-router-dom'
 import LoginPage from './pages/loginPage'
 import HomePage from './pages/homePage'
+import ProtectedRoute from './components/protectedRoute'
 
 function App() {
   return (
@@ -10,7 +11,9 @@ function App() {
       {/* Routes for the app */}
       <Routes>
         <Route path="/login" element={<LoginPage />} />
-        <Route path="/" element={<HomePage />} />
+        <Route element={<ProtectedRoute />}>
+          <Route path="/" element={<HomePage />} />
+        </Route>
       </Routes>
     </NextUIProvider>
   )

--- a/frontend/src/components/protectedRoute.tsx
+++ b/frontend/src/components/protectedRoute.tsx
@@ -1,0 +1,22 @@
+import { AuthStore } from '../context/auth.store'
+import { Navigate } from 'react-router-dom'
+import { Outlet } from 'react-router-dom'
+
+interface props {
+  children?: React.ReactNode
+}
+
+function ProtectedRoute({ children }: props): JSX.Element {
+  const isAuthenticated = AuthStore((state) => state.isAuthenticated)
+  const verifyToken = AuthStore((state) => state.verifyToken)
+
+  verifyToken()
+
+  if (!isAuthenticated) {
+    return <Navigate to={'/login'} />
+  }
+
+  return children ? <>{children}</> : <Outlet />
+}
+
+export default ProtectedRoute

--- a/frontend/src/context/auth.store.ts
+++ b/frontend/src/context/auth.store.ts
@@ -27,12 +27,15 @@ type Actions = {
     password: string,
     role: string
   ) => Promise<void>
+
+  // verify token
+  verifyToken: () => Promise<void>
 }
 
 // this is where the store is created
 export const AuthStore = create<State & Actions>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       // state
       isAuthenticated: false,
       isLoading: false,
@@ -43,9 +46,7 @@ export const AuthStore = create<State & Actions>()(
       login: async (username: string, password: string) => {
         try {
           const response = await authServices.login(username, password)
-          console.log(response.data.token)
-          set({ token: response.data.token })
-          console.log('authenticated')
+          set({ token: response.data.token, isAuthenticated: true })
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
@@ -79,6 +80,21 @@ export const AuthStore = create<State & Actions>()(
               status: error.response.status,
             },
           })
+        }
+      },
+      // verify token action
+      verifyToken: async () => {
+        try {
+          const token = get().token
+          if (token && token != '') {
+            console.log(token)
+            set({ isAuthenticated: true })
+            return
+          }
+          throw new Error('There is no valid token')
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        } catch (_) {
+          set({ isAuthenticated: false })
         }
       },
     }),

--- a/frontend/src/context/auth.store.ts
+++ b/frontend/src/context/auth.store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 import authServices from '../services/auth.services'
 
 type Error = {
@@ -10,14 +11,15 @@ type Error = {
 type State = {
   isAuthenticated: boolean
   isLoading: boolean
-  user: string | null
-  token: string | null
+  token: string
   error: Error | null
 }
 
 // actions are functions that can be called to update the state
 type Actions = {
+  // login
   login: (email: string, password: string) => Promise<void>
+  // register
   register: (
     username: string,
     email: string,
@@ -28,53 +30,62 @@ type Actions = {
 }
 
 // this is where the store is created
-export const AuthStore = create<State & Actions>()((set) => ({
-  // state
-  isAuthenticated: false,
-  isLoading: false,
-  user: null,
-  token: null,
-  error: null,
+export const AuthStore = create<State & Actions>()(
+  persist(
+    (set) => ({
+      // state
+      isAuthenticated: false,
+      isLoading: false,
+      token: '',
+      error: null,
 
-  // actions
-  login: async (username: string, password: string) => {
-    try {
-      const response = await authServices.login(username, password)
-      console.log(response.data.token)
-      set({ token: response.data.token, isAuthenticated: true })
-      console.log('authenticated')
+      // login action
+      login: async (username: string, password: string) => {
+        try {
+          const response = await authServices.login(username, password)
+          console.log(response.data.token)
+          set({ token: response.data.token })
+          console.log('authenticated')
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      console.log(error.response.data?.message || error.response.data?.error)
-      set({
-        error: {
-          message: error.response.data?.message || error.response.data?.error,
-          status: error.response.status,
-        },
-      })
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+          console.log(error.response.data?.message || error.response.data?.error)
+          set({
+            error: {
+              message: error.response.data?.message || error.response.data?.error,
+              status: error.response.status,
+            },
+          })
+        }
+      },
+      // register action
+      register: async (
+        username: string,
+        email: string,
+        name: string,
+        password: string,
+        role: string
+      ) => {
+        try {
+          const response = await authServices.register(username, email, name, password, role)
+          console.log(response)
+
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+          console.log(error.response.data?.message || error.response.data?.error)
+          set({
+            error: {
+              message: error.response.data?.message || error.response.data?.error,
+              status: error.response.status,
+            },
+          })
+        }
+      },
+    }),
+    {
+      name: 'token', // unique name
+      // ignore the storage to avoid conflicts with other stores
+      partialize: (state) => ({ token: state.token }),
     }
-  },
-  register: async (
-    username: string,
-    email: string,
-    name: string,
-    password: string,
-    role: string
-  ) => {
-    try {
-      const response = await authServices.register(username, email, name, password, role)
-      console.log(response)
-
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      console.log(error.response.data?.message || error.response.data?.error)
-      set({
-        error: {
-          message: error.response.data?.message || error.response.data?.error,
-          status: error.response.status,
-        },
-      })
-    }
-  },
-}))
+  )
+)

--- a/frontend/src/pages/loginPage.tsx
+++ b/frontend/src/pages/loginPage.tsx
@@ -2,6 +2,8 @@ import { useForm, SubmitHandler } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { AuthStore } from '../context/auth.store'
 import * as yup from 'yup'
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
 
 type Input = {
   username: string
@@ -17,8 +19,16 @@ const schema = yup
 
 function LoginPage() {
   // get the login function from the store
+  const navigate = useNavigate()
   const login = AuthStore((state) => state.login)
   const loginError = AuthStore((state) => state.error)
+  const isAuthenticated = AuthStore((state) => state.isAuthenticated)
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigate('/')
+    }
+  }, [isAuthenticated])
 
   // use the useForm hook to handle the form
   const {

--- a/frontend/src/services/axios.ts
+++ b/frontend/src/services/axios.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { AuthStore } from '../context/auth.store'
 
 // create the instance config
 const instance = axios.create({
@@ -12,8 +13,8 @@ export default instance
 // add a request interceptor to add the token into every request before sending
 instance.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('token')
-    if (token && config.headers) {
+    const token = AuthStore.getState().token
+    if (token && token.length > 0 && config.headers) {
       // if there is a token saved it will attach it to the request
       config.headers.Authorization = `Bearer ${token}`
     }


### PR DESCRIPTION
i used the zustand persist middleware to get the token into the localStorage when getting one, then make another auth action which is verifying a token, as i cannot use jwt to verify a token in the front because that means using the secret key in the front i only verify that there is a token and if there is a token then, the user is authorized